### PR TITLE
Pyodide: load packages imported in code

### DIFF
--- a/example-nextjs/pages/index.tsx
+++ b/example-nextjs/pages/index.tsx
@@ -7,13 +7,14 @@ declare global {
   interface Window {
     pyodide: any
     languagePluginLoader: any
+    loadPyodide: Function
   }
 }
 
 function App() {
   const [output, setOutput] = useState('loading...')
   const [inputCode, setInputCode] = useState('')
-  const [pyodide, setPyodide] = useState(false)
+  const [pyodide, setPyodide] = useState(null)
 
   async function runCode(code: string, pyodide: any) {
     console.log('running code', code)
@@ -35,9 +36,12 @@ function App() {
         {/* Content goes here */}
         <>
           <Script
-            src="https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js"
-            onLoad={() => {
-              setPyodide(true)
+            src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
+            onLoad={async () => {
+              const pyodide = await window.loadPyodide({
+                indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.18.1/full/',
+              })
+              setPyodide(pyodide)
             }}
           />
         </>
@@ -63,7 +67,7 @@ function App() {
         {pyodide && (
           <button
             className="bg-black text-white my-4 py-1 px-2 rounded-lg "
-            onClick={() => runCode(inputCode, window.pyodide)}
+            onClick={() => runCode(inputCode, pyodide)}
           >
             Run Code
           </button>

--- a/src/RunWasmClient.ts
+++ b/src/RunWasmClient.ts
@@ -17,9 +17,18 @@ export class PythonClient {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public constructor(protected pyodide: any) {}
 
+  private loadPackages(code: string): Promise<any> {
+    if (typeof this.pyodide.loadPackagesFromImports === 'function') {
+      console.log('Loading Python dependencies from code')
+      return this.pyodide.loadPackagesFromImports(code)
+    } else {
+      return this.pyodide.loadPackage([])
+    }
+  }
+
   public run({ code }: { code: string }): Promise<string> {
     return new Promise((resolve) => {
-      const output = this.pyodide.loadPackage([]).then(() => {
+      const output = this.loadPackages(code).then(() => {
         const output = this.pyodide.runPython(code)
         console.log(output)
         return output


### PR DESCRIPTION
This PR updates the `PythonClient.run` function to load Python packages imported  in the code to be run, before running the code. See Pyodide documentation: https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.loadPackagesFromImports

This feature isn't available in the 0.16.1 version currently used in example-nextjs. So I've updated it to the newest version 0.18.1 in order to take advantage of this feature. There are some changes to how this version loads - see Pyodide documentation: https://pyodide.org/en/stable/usage/index.html#web-browsers

This means that importing eg. numpy now works:

<img width="807" alt="Screenshot 2021-09-22 at 12 14 59" src="https://user-images.githubusercontent.com/1711350/134333970-afa8b2c3-7805-4424-bdab-b94040634dcd.png">
