### PR TITLE
Fix non-console lint warnings.

### DIFF
--- a/src/RunWasmClient.ts
+++ b/src/RunWasmClient.ts
@@ -27,25 +27,20 @@ export class PythonClient {
     pyodide.runPython(this.setStdoutToOutput)
   }
 
+  public async run({ code }: { code: string }): Promise<string> {
+    await this.loadPackages(code)
+    const output: string = this.pyodide.runPython(code) ?? ''
+    // Prepend the value of stdout before returning
+    const stdout: string = this.pyodide.runPython('sys.stdout.getvalue()')
+    console.log(stdout + output)
+    return stdout + output
+  }
+
   private loadPackages(code: string): Promise<any> {
     if (typeof this.pyodide.loadPackagesFromImports === 'function') {
       console.log('Loading Python dependencies from code')
       return this.pyodide.loadPackagesFromImports(code)
-    } else {
-      return this.pyodide.loadPackage([])
     }
-  }
-
-  public run({ code }: { code: string }): Promise<string> {
-    return new Promise((resolve) => {
-      const output = this.loadPackages(code).then(() => {
-        const output = this.pyodide.runPython(code) ?? ''
-        // Prepend the value of stdout before returning
-        const stdout = this.pyodide.runPython('sys.stdout.getvalue()')
-        console.log(stdout + output)
-        return stdout + output
-      })
-      resolve(output)
-    })
+    return this.pyodide.loadPackage([])
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/consistent-function-scoping */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react'
 import { RunWasmClient, PythonClient } from './RunWasmClient'


### PR DESCRIPTION
There are a few lint warnings ([`@typescript-eslint/member-ordering`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.22.0/packages/eslint-plugin/docs/rules/member-ordering.md), [`@typescript-eslint/restrict-plus-operands`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.22.0/packages/eslint-plugin/docs/rules/restrict-plus-operands.md), [`no-else-return`](https://eslint.org/docs/rules/no-else-return), and an unused disable comment) that have been corrected.  As there is no logging system at the moment, I have left the warnings regarding [`no-console`](https://eslint.org/docs/rules/no-console).