### PR TITLE
fix: update Pyodide loading to remove Script onLoad

### DIFF
--- a/example-nextjs/pages/index.tsx
+++ b/example-nextjs/pages/index.tsx
@@ -45,21 +45,22 @@ eratosthenes(100)`)
     console.log(inputCode)
   }, [inputCode])
 
+  // Note that window.loadPyodide comes from the beforeInteractive pyodide.js Script
+  useEffect(() => {
+    window
+      .loadPyodide({
+        indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.18.1/full/',
+      })
+      .then((pyodide) => setPyodide(pyodide))
+  }, [])
+
   return (
     <div className="max-w-4xl px-4 py-16 mx-auto sm:px-6 lg:px-8">
       <div className="max-w-3xl mx-auto">
-        {/* Content goes here */}
-        <>
-          <Script
-            src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
-            onLoad={async () => {
-              const pyodide = await window.loadPyodide({
-                indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.18.1/full/',
-              })
-              setPyodide(pyodide)
-            }}
-          />
-        </>
+        <Script
+          src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
+          strategy="beforeInteractive"
+        />
         <main className="mx-auto my-16 max-w-7xl sm:mt-24">
           <div className="text-left">
             <h1 className="text-3xl tracking-tight text-gray-900 sm:text-5xl md:text-5xl">


### PR DESCRIPTION
Closes: #33 

Much more detailed discussion on the issue, but in summary:

- We don't think the CDN is flaky
- We sometimes see `window.loadPyodide` unavailable in the `onLoad` of the script that should have loaded it

This PR refactors the loading so that:

- The initial script (small, puts window.loadPyodide) is now loaded as `beforeInteractive`
- The previous `onLoad` is moved into a `useEffect` hook, which as before loads `pyodide` + sets the state

Hopefully this is a more robust way to load Pyodide in a React app! 