### PR TITLE
Loading tsc libs

### DIFF
--- a/example-nextjs/pages/ts.tsx
+++ b/example-nextjs/pages/ts.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { createTSClient } from 'run-wasm'
 import Editor from '@monaco-editor/react'
 import Script from 'next/script'
@@ -20,9 +20,14 @@ b = 3;
 console.log(a + b);`)
   const [output, setOutput] = useState<Array<string>>([])
   const [errors, setErrors] = useState<Array<string>>([])
+  const [tsClient, setTsClient] = useState<any>(null)
+
+  useEffect(() => {
+    const tsClient = createTSClient(window.ts)
+    tsClient.fetchLibs(['es5', 'dom']).then(() => setTsClient(tsClient))
+  }, [])
 
   async function runCode(code: string) {
-    let tsClient = createTSClient(window.ts)
     const { errors: err, output: result } = await tsClient.run({ code })
     setOutput(result)
     setErrors(err)

--- a/src/RunWasmClient.ts
+++ b/src/RunWasmClient.ts
@@ -151,10 +151,5 @@ function getTSTypeErrors(code: string, ts: any, libData: any[]): string[] {
   return ts
     .getPreEmitDiagnostics(program)
     .filter((d: { file: any }) => d.file)
-    .filter(
-      (d: { messageText: string }) =>
-        // Ignoring an error that says that console is not in scope (more about it here: https://stackoverflow.com/a/53764522 (check the imperfect example section))
-        !d.messageText.startsWith("Cannot find name 'console'")
-    )
     .map((d: { messageText: string }) => d.messageText)
 }

--- a/src/RunWasmClient.ts
+++ b/src/RunWasmClient.ts
@@ -70,7 +70,7 @@ export class TSClient {
     }
   }
 
-  public fetchLibs(libs: string[]): void {
+  public async fetchLibs(libs: string[]): Promise<void> {
     this.libData = Promise.all(
       libs.map(async (lib: string) => {
         const path = `typescript/lib/lib.${lib}.d.ts`
@@ -120,7 +120,7 @@ function getTSTypeErrors(code: string, ts: any, libData: any[]): string[] {
     ts.ScriptTarget.Latest
   )
   const options = {
-    lib: ['es5', 'dom'],
+    lib: [...libData],
   }
 
   const host = {


### PR DESCRIPTION
Once ready to be merged this will solve #68 and #69. I've added some logic into the constructor to fetch the lib content, and then await its resolution in the run function. That libData is then passed on to the `getTsTypeErrors` function as a third parameter so that its available when the `ts.createProgram` call is made. 

The most significant changes are in the `TSClient` constructor with the addition of this code:
```js
    const libs: string[] = ['es5', 'dom']

    const fetchLibs = async (libs: string[]) => {
      return Promise.all(
        libs.map(async (lib: string) => {
          const path = `typescript/lib/lib.${lib}.d.ts`
          const content = await fetch(
            `https://cdn.jsdelivr.net/npm/typescript@4.4.3/lib/lib.${lib}.d.ts`
          )
            .then((res) => res.text())
            .catch(() => console.log('Failed to load lib: ' + lib))

          return {
            path,
            content,
            ast: ts.createSourceFile(path, content, ts.ScriptTarget.Latest),
          }
        })
      ).then((libs) => libs)
    }

    this.libData = fetchLibs(libs)
```

And the `getTsTypeErrors` function which now looks like so:
```js
function getTSTypeErrors(code: string, ts: any, libData: any[]): string[] {
  const dummyFilePath = '/file.ts'
  const textAst = ts.createSourceFile(
    dummyFilePath,
    code,
    ts.ScriptTarget.Latest
  )
  const options = {
    lib: ['es5', 'dom'],
  }

  const host = {
    fileExists: (filePath: string) =>
      filePath === dummyFilePath || filePath.startsWith('typescript/lib/'),
    directoryExists: (dirPath: string) => dirPath === '/',
    getCurrentDirectory: () => '/',
    getDirectories: () => [],
    getCanonicalFileName: (fileName: any) => fileName,
    getNewLine: () => '\n',
    getDefaultLibFileName: () => '',
    getSourceFile: (filePath: string) =>
      filePath === dummyFilePath
        ? textAst
        : libData.find((lib) => lib.path === filePath)?.ast,
    readFile: (filePath: string) =>
      filePath === dummyFilePath
        ? code
        : libData.find((lib) => lib.path === filePath)?.content,
    useCaseSensitiveFileNames: () => true,
    // eslint-disable-next-line @typescript-eslint/no-empty-function
    writeFile: () => {},
  }

  const rootNames = libData.map((lib) => lib.path)

  const program = ts.createProgram([...rootNames, dummyFilePath], options, host)

  return ts
    .getPreEmitDiagnostics(program)
    .filter((d: { file: any }) => d.file)
    .map((d: { messageText: string }) => d.messageText)
}
```

I have also removed the code that filters out messages about the name "console" not being found since this should fix that as well. This is my first experience with TypeScript and your codebase so I'm happy to receive any criticism. 