### PR TITLE
fix: use hero icons for dark mode toggle

### DIFF
--- a/example-nextjs/components/Navbar.tsx
+++ b/example-nextjs/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import { Disclosure } from '@headlessui/react'
 import { MenuIcon, XIcon } from '@heroicons/react/outline'
+import { SunIcon, MoonIcon } from '@heroicons/react/solid'
 import Logo from './Logo'
 import useDarkMode from '../hooks/useDarkMode'
 
@@ -56,36 +57,15 @@ export default function Navbar({ current }) {
                         setTheme(theme === 'light' ? 'dark' : 'light')
                       }
                       className={
-                        'rounded-full self-center flex items-center justify-center h-8 w-8 bg-white shadow-inner border border-gray-100 capitalize'
+                        'rounded-full self-center flex items-center justify-center h-8 w-8 p-1.5 bg-white shadow-inner border border-gray-100 capitalize'
                       }
                     >
-                      {theme === 'dark' ? (
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="w-5 h-5"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-                            clipRule="evenodd"
-                          />
-                        </svg>
-                      ) : (
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="w-5 h-5"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                        >
-                          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-                        </svg>
-                      )}
+                      {theme === 'dark' ? (<SunIcon></SunIcon>) : (<MoonIcon></MoonIcon>)}
                     </button>
                   </div>
                 </div>
                 <div className="flex items-center -mr-2 sm:hidden">
+
                   {/* Mobile menu button */}
                   <Disclosure.Button className="inline-flex items-center justify-center p-2 text-gray-400 rounded-md hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-gray-500">
                     <span className="sr-only">Open main menu</span>


### PR DESCRIPTION
It was already using hero icons in SVG format... just switched to using the HeroIcons components and adjusted styles a bit.