### PR TITLE
fix: screen flash on changing themes

### DIFF
--- a/example-nextjs/components/Navbar.tsx
+++ b/example-nextjs/components/Navbar.tsx
@@ -82,9 +82,9 @@ export default function Navbar({ current }) {
                     }
                   >
                     {mounted && resolvedTheme === 'dark' ? (
-                      <SunIcon></SunIcon>
+                      <SunIcon className="w-5 h-5"></SunIcon>
                     ) : (
-                      <MoonIcon></MoonIcon>
+                      <MoonIcon className="w-5 h-5"></MoonIcon>
                     )}
                   </button>
                   {/* Mobile menu button */}

--- a/example-nextjs/components/Navbar.tsx
+++ b/example-nextjs/components/Navbar.tsx
@@ -1,15 +1,15 @@
 import { Disclosure } from '@headlessui/react'
 import { MenuIcon, XIcon } from '@heroicons/react/outline'
 import Logo from './Logo'
-import useDarkMode from '../hooks/useDarkMode'
+import { useTheme } from 'next-themes'
+import React from 'react'
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ')
 }
 
 export default function Navbar({ current }) {
-  const [theme, setTheme] = useDarkMode()
-
+  const { theme, setTheme } = useTheme()
   const navigation = [
     { name: 'Home', href: '/', current: current === 'Home' },
     {
@@ -59,27 +59,25 @@ export default function Navbar({ current }) {
                         'rounded-full self-center flex items-center justify-center h-8 w-8 bg-white shadow-inner border border-gray-100 capitalize'
                       }
                     >
-                      {theme === 'dark' ? (
+                      {theme === 'light' ? (
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           className="w-5 h-5"
                           viewBox="0 0 20 20"
-                          fill="currentColor"
                         >
-                          <path
-                            fillRule="evenodd"
-                            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-                            clipRule="evenodd"
-                          />
+                          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
                         </svg>
                       ) : (
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           className="w-5 h-5"
                           viewBox="0 0 20 20"
-                          fill="currentColor"
                         >
-                          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+                          <path
+                            fillRule="evenodd"
+                            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+                            clipRule="evenodd"
+                          />
                         </svg>
                       )}
                     </button>

--- a/example-nextjs/package.json
+++ b/example-nextjs/package.json
@@ -14,6 +14,7 @@
     "@monaco-editor/react": "^4.2.2",
     "fathom-client": "^3.0.0",
     "next": "11.1.2",
+    "next-themes": "^0.0.15",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "run-wasm": "link:.."

--- a/example-nextjs/pages/_app.tsx
+++ b/example-nextjs/pages/_app.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import type { AppProps } from 'next/app'
 import { useEffect } from 'react'
 import Layout from '../components/Layout'
+import { ThemeProvider } from 'next-themes'
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
@@ -31,9 +32,11 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, [])
 
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <ThemeProvider attribute="class">
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </ThemeProvider>
   )
 }
 export default MyApp

--- a/example-nextjs/pages/_document.tsx
+++ b/example-nextjs/pages/_document.tsx
@@ -1,0 +1,22 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body className="bg-white dark:bg-gray-875">
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/example-nextjs/yarn.lock
+++ b/example-nextjs/yarn.lock
@@ -2296,6 +2296,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+next-themes@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.0.15.tgz#ab0cee69cd763b77d41211f631e108beab39bf7d"
+  integrity sha512-LTmtqYi03c4gMTJmWwVK9XkHL7h0/+XrtR970Ujvtu3s0kZNeJN24aJsi4rkZOI8i19+qq6f8j+8Duwy5jqcrQ==
+
 next@11.1.2:
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/next/-/next-11.1.2.tgz#527475787a9a362f1bc916962b0c0655cc05bc91"


### PR DESCRIPTION
Attempts to fix #75 

There are 2 approaches for this issue

1. Run a script in the `<head>` tag

This works well when was have theme data attribute in the HTML element So when the page loads we can get the theme based on preference and localStorage and assign it before the `<body>` starts executing.

```js
const docHtml = document.documentElement.dataset;
docHtml.theme =getTheme();
```

and then we add it  to `_document.tsx`

```tsx
import Document, { Html, Head, Main, NextScript } from 'next/document';
import React from 'react';

class MyDocument extends Document {
    render() {
        return (
            <Html lang="en">
                <Head>
                    {/* To Avoid Flickering */}
                    <script type="text/javascript" src="/static/theme.js" />
                </Head>
                <body>
                    <Main />
                    <NextScript />
                </body>
            </Html>
        );
    }
}

export default MyDocument;
```

--- 


Since we aren't using the data theme attribute here instead we are assigning the theme based on className to the `body` element.

2. Using [`next-themes`](https://github.com/pacocoursey/next-themes)


Things I have done in this PR:

- added the package `next-themes` (1.59 kb)
- wrapped app component with `<ThemeProvider />`
- by default `next-themes` uses data attribute so passing `attribute="class"`
- adding base styles to body `<body className="bg-white dark:bg-gray-875">`
- using `useTheme()` hook to get current theme and setTheme function to toggle

Some implementations 

https://github.com/leerob/leerob.io/blob/7bd1fdfdb0f5bf7ad0945b14f7a0da26eaa68c11/pages/_app.tsx#L13
