### PR TITLE
feat: extract Editor component into core package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'import/order': 'off',
     '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/consistent-type-definitions': 'off',
+    'unicorn/no-abusive-eslint-disable': 'off',
   },
   env: {
     jest: true,

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Bootstrap and run the Build
         run: yarn bootstrap --no-ci
 
+      # Links React dependency
+      - name: Linking dependencies
+        working-directory: ./example-nextjs
+        run: yarn link-react
+
       # Runs the tests
       - name: Run tests
         run: yarn test

--- a/example-nextjs/components/CodeRunnerUI.tsx
+++ b/example-nextjs/components/CodeRunnerUI.tsx
@@ -9,6 +9,7 @@ interface Props {
   onRunCode(inputCode: string): Promise<string | void>
   languageLabel: string
   isLoading?: boolean
+  children?: React.ReactNode
   hideOutputEditor?: boolean
 }
 
@@ -19,6 +20,7 @@ export default function CodeRunnerUI(props: Props) {
     hideOutputEditor,
     isLoading = false,
     defaultLanguage,
+    children,
     onRunCode,
   } = props
 

--- a/example-nextjs/components/CodeRunnerUI.tsx
+++ b/example-nextjs/components/CodeRunnerUI.tsx
@@ -10,7 +10,6 @@ interface Props {
   onRunCode(inputCode: string): Promise<string | void>
   languageLabel: string
   isLoading?: boolean
-  children?: React.ReactNode
   hideOutputEditor?: boolean
 }
 
@@ -21,7 +20,6 @@ export default function CodeRunnerUI(props: Props) {
     hideOutputEditor,
     isLoading = false,
     defaultLanguage,
-    children,
     onRunCode,
   } = props
 

--- a/example-nextjs/components/CodeRunnerUI.tsx
+++ b/example-nextjs/components/CodeRunnerUI.tsx
@@ -63,7 +63,9 @@ export default function CodeRunnerUI(props: Props) {
           isLoading={isLoading}
           defaultLanguage={defaultLanguage}
           onRunCode={runCode}
-        />
+        >
+          {children}
+        </Editor>
       </div>
     </>
   )

--- a/example-nextjs/components/CodeRunnerUI.tsx
+++ b/example-nextjs/components/CodeRunnerUI.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react'
-import Editor, { Monaco } from '@monaco-editor/react'
 import Script from 'next/script'
 import GithubButton from './GithubButton'
 import Navbar from './Navbar'
-import { addKeyBinding, CustomKeyBinding } from '../utils'
+import Editor from './Editor'
 
 interface Props {
   defaultLanguage?: string
@@ -25,35 +24,6 @@ export default function CodeRunnerUI(props: Props) {
     children,
     onRunCode,
   } = props
-  const inputCodeRef = React.useRef(initialCode)
-  const [output, setOutput] = React.useState('')
-  const editorRef = React.useRef(null)
-  const [monaco, setMonaco] = React.useState<Monaco>(null)
-
-  async function runCode(code: string) {
-    const output = await onRunCode(code)
-    if (output) {
-      setOutput(output)
-    }
-  }
-
-  function handleEditorDidMount(editor: any, monaco: Monaco) {
-    editorRef.current = editor
-    setMonaco(monaco)
-  }
-
-  React.useEffect(() => {
-    if (!monaco || isLoading) {
-      return
-    }
-    const runCodeBinding: CustomKeyBinding = {
-      label: 'run',
-      keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-      callback: () => runCode(inputCodeRef.current),
-      editor: editorRef.current,
-    }
-    return addKeyBinding(runCodeBinding)
-  }, [monaco, isLoading])
 
   return (
     <>
@@ -80,68 +50,15 @@ export default function CodeRunnerUI(props: Props) {
               <GithubButton />
             </div>
           </main>
-
-          <div>
-            <label className="block pb-4 text-sm font-medium text-gray-700 dark:text-gray-450">
-              {languageLabel}
-            </label>
-
-            <div className="mt-1 ">
-              <div className="relative group">
-                <div className="absolute -inset-0.5 dark:bg-gradient-to-r from-indigo-300 to-purple-400 rounded-lg blur opacity-25 group-hover:opacity-100 transition duration-1000 group-hover:duration-200 animate-tilt" />
-                <Editor
-                  height="20rem"
-                  defaultLanguage={defaultLanguage}
-                  defaultValue={inputCodeRef.current}
-                  onChange={(value) => {
-                    inputCodeRef.current = value
-                  }}
-                  className="block w-1/2  text-white bg-gray-900 border-gray-300 rounded-lg   shadow-sm p-0.5 border   dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
-                  theme="vs-dark"
-                  options={{ fontSize: 12 }}
-                  onMount={handleEditorDidMount}
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="pt-8 ">
-            <div className="grid items-start justify-left">
-              <div className="relative group">
-                <button
-                  className="relative flex items-center py-4 leading-none bg-black divide-x divide-gray-600 rounded-lg px-7 border-gray-300 disabled:bg-gray-700 disabled:cursor-not-allowed"
-                  onClick={() => runCode(inputCodeRef.current)}
-                  disabled={isLoading}
-                >
-                  <span className="text-gray-100 transition duration-200 group-hover:text-gray-100">
-                    {!isLoading ? 'Run Code →' : `Loading ${languageLabel}...`}
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {children}
-
-          {!hideOutputEditor && (
-            <div>
-              <label className="block pt-8 text-sm font-medium text-gray-700 dark:text-gray-450">
-                Output
-              </label>
-
-              <div className="mt-1 dark:text-gray-450">
-                <Editor
-                  value={output?.toString()}
-                  height="20rem"
-                  defaultLanguage="python"
-                  className="block w-1/2  text-white bg-gray-900 border-gray-300 rounded-lg   shadow-sm p-0.5 border   dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
-                  theme="vs-dark"
-                  options={{ readOnly: true }}
-                />
-              </div>
-            </div>
-          )}
         </div>
+        <Editor
+          initialCode={initialCode}
+          languageLabel={languageLabel}
+          hideOutputEditor={hideOutputEditor}
+          isLoading={isLoading}
+          defaultLanguage={defaultLanguage}
+          onRunCode={onRunCode}
+        />
       </div>
     </>
   )

--- a/example-nextjs/components/CodeRunnerUI.tsx
+++ b/example-nextjs/components/CodeRunnerUI.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
+import Script from 'next/script'
 import GithubButton from './GithubButton'
 import Navbar from './Navbar'
-import Editor from './Editor'
+import { Editor } from '@run-wasm/run-wasm'
 
 interface Props {
   defaultLanguage?: string
@@ -38,6 +39,10 @@ export default function CodeRunnerUI(props: Props) {
       <Navbar current={languageLabel} />
       <div className="max-w-4xl px-4 py-8 mx-auto sm:px-6 lg:px-8">
         <div className="max-w-3xl mx-auto">
+          <Script
+            src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
+            strategy="beforeInteractive"
+          />
           <main className="mx-auto mb-12 max-w-7xl sm:mt-12">
             <div className="text-left">
               <h1 className="text-3xl tracking-tight text-gray-900 dark:text-white sm:text-5xl md:text-5xl">

--- a/example-nextjs/components/CodeRunnerUI.tsx
+++ b/example-nextjs/components/CodeRunnerUI.tsx
@@ -23,6 +23,15 @@ export default function CodeRunnerUI(props: Props) {
     onRunCode,
   } = props
 
+  const [output, setOutput] = React.useState('')
+
+  async function runCode(code: string) {
+    const output = await onRunCode(code)
+    if (output) {
+      setOutput(output)
+    }
+  }
+
   return (
     <>
       <Navbar current={languageLabel} />
@@ -51,11 +60,12 @@ export default function CodeRunnerUI(props: Props) {
         </div>
         <Editor
           initialCode={initialCode}
+          output={output}
           languageLabel={languageLabel}
           hideOutputEditor={hideOutputEditor}
           isLoading={isLoading}
           defaultLanguage={defaultLanguage}
-          onRunCode={onRunCode}
+          onRunCode={runCode}
         />
       </div>
     </>

--- a/example-nextjs/components/CodeRunnerUI.tsx
+++ b/example-nextjs/components/CodeRunnerUI.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import Script from 'next/script'
 import GithubButton from './GithubButton'
 import Navbar from './Navbar'
 import Editor from './Editor'
@@ -37,10 +36,6 @@ export default function CodeRunnerUI(props: Props) {
       <Navbar current={languageLabel} />
       <div className="max-w-4xl px-4 py-8 mx-auto sm:px-6 lg:px-8">
         <div className="max-w-3xl mx-auto">
-          <Script
-            src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
-            strategy="beforeInteractive"
-          />
           <main className="mx-auto mb-12 max-w-7xl sm:mt-12">
             <div className="text-left">
               <h1 className="text-3xl tracking-tight text-gray-900 dark:text-white sm:text-5xl md:text-5xl">

--- a/example-nextjs/components/Editor.tsx
+++ b/example-nextjs/components/Editor.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react'
+import MonacoEditor, { Monaco } from '@monaco-editor/react'
+import { addKeyBinding, CustomKeyBinding } from '../utils'
+
+interface Props {
+  initialCode: string
+  languageLabel: string
+  hideOutputEditor?: boolean
+  isLoading?: boolean
+  defaultLanguage?: string
+  onRunCode(inputCode: string): Promise<string | void>
+  children?: React.ReactNode
+}
+
+export default function Editor(props: Props) {
+  const {
+    initialCode,
+    languageLabel,
+    hideOutputEditor,
+    isLoading = false,
+    defaultLanguage,
+    onRunCode,
+    children,
+  } = props
+
+  const inputCodeRef = React.useRef(initialCode)
+  const editorRef = React.useRef(null)
+
+  const [monaco, setMonaco] = React.useState<Monaco>(null)
+  const [output, setOutput] = React.useState('')
+
+  async function runCode(code: string) {
+    const output = await onRunCode(code)
+    if (output) {
+      setOutput(output)
+    }
+  }
+
+  function handleEditorDidMount(editor: any, monaco: Monaco) {
+    editorRef.current = editor
+    setMonaco(monaco)
+  }
+
+  React.useEffect(() => {
+    if (!monaco || isLoading) {
+      return
+    }
+    const runCodeBinding: CustomKeyBinding = {
+      label: 'run',
+      keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+      callback: () => runCode(inputCodeRef.current),
+      editor: editorRef.current,
+    }
+    return addKeyBinding(runCodeBinding)
+  }, [monaco, isLoading])
+
+  return (
+    <>
+      <div>
+        <div>
+          <label className="block pb-4 text-sm font-medium text-gray-700 dark:text-gray-450">
+            {languageLabel}
+          </label>
+
+          <div className="mt-1 ">
+            <div className="relative group">
+              <div className="absolute -inset-0.5 dark:bg-gradient-to-r from-indigo-300 to-purple-400 rounded-lg blur opacity-25 group-hover:opacity-100 transition duration-1000 group-hover:duration-200 animate-tilt" />
+              <MonacoEditor
+                height="20rem"
+                defaultLanguage={defaultLanguage}
+                defaultValue={inputCodeRef.current}
+                onChange={(value) => {
+                  inputCodeRef.current = value
+                }}
+                className="block w-1/2  text-white bg-gray-900 border-gray-300 rounded-lg   shadow-sm p-0.5 border   dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
+                theme="vs-dark"
+                options={{ fontSize: 12 }}
+                onMount={handleEditorDidMount}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="pt-8 ">
+        <div className="grid items-start justify-left">
+          <div className="relative group">
+            <button
+              className="relative flex items-center py-4 leading-none bg-black divide-x divide-gray-600 rounded-lg px-7 border-gray-300 disabled:bg-gray-700 disabled:cursor-not-allowed"
+              onClick={() => runCode(inputCodeRef.current)}
+              disabled={isLoading}
+            >
+              <span className="text-gray-100 transition duration-200 group-hover:text-gray-100">
+                {!isLoading ? 'Run Code →' : `Loading ${languageLabel}...`}
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {children}
+
+      {!hideOutputEditor && (
+        <div>
+          <label className="block pt-8 text-sm font-medium text-gray-700 dark:text-gray-450">
+            Output
+          </label>
+
+          <div className="mt-1 dark:text-gray-450">
+            <MonacoEditor
+              value={output?.toString()}
+              height="20rem"
+              defaultLanguage="python"
+              className="block w-1/2 text-white bg-gray-900 border-gray-300 rounded-lg shadow-sm p-0.5 border dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
+              theme="vs-dark"
+              options={{ readOnly: true }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/example-nextjs/components/Editor.tsx
+++ b/example-nextjs/components/Editor.tsx
@@ -68,7 +68,7 @@ export default function Editor(props: Props) {
                 }}
                 className="block w-1/2  text-white bg-gray-900 border-gray-300 rounded-lg   shadow-sm p-0.5 border   dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
                 theme="vs-dark"
-                options={{ fontSize: 12 }}
+                options={{ fontSize: 12, minimap: { enabled: false } }}
                 onMount={handleEditorDidMount}
               />
             </div>
@@ -107,7 +107,11 @@ export default function Editor(props: Props) {
               defaultLanguage="python"
               className="block w-1/2 text-white bg-gray-900 border-gray-300 rounded-lg shadow-sm p-0.5 border dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
               theme="vs-dark"
-              options={{ readOnly: true }}
+              options={{
+                readOnly: true,
+                fontSize: 12,
+                minimap: { enabled: false },
+              }}
             />
           </div>
         </div>

--- a/example-nextjs/components/Editor.tsx
+++ b/example-nextjs/components/Editor.tsx
@@ -4,6 +4,7 @@ import { addKeyBinding, CustomKeyBinding } from '../utils'
 
 interface Props {
   initialCode: string
+  output: string
   languageLabel: string
   hideOutputEditor?: boolean
   isLoading?: boolean
@@ -15,6 +16,7 @@ interface Props {
 export default function Editor(props: Props) {
   const {
     initialCode,
+    output,
     languageLabel,
     hideOutputEditor,
     isLoading = false,
@@ -27,14 +29,6 @@ export default function Editor(props: Props) {
   const editorRef = React.useRef(null)
 
   const [monaco, setMonaco] = React.useState<Monaco>(null)
-  const [output, setOutput] = React.useState('')
-
-  async function runCode(code: string) {
-    const output = await onRunCode(code)
-    if (output) {
-      setOutput(output)
-    }
-  }
 
   function handleEditorDidMount(editor: any, monaco: Monaco) {
     editorRef.current = editor
@@ -48,7 +42,7 @@ export default function Editor(props: Props) {
     const runCodeBinding: CustomKeyBinding = {
       label: 'run',
       keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-      callback: () => runCode(inputCodeRef.current),
+      callback: () => onRunCode(inputCodeRef.current),
       editor: editorRef.current,
     }
     return addKeyBinding(runCodeBinding)
@@ -87,7 +81,7 @@ export default function Editor(props: Props) {
           <div className="relative group">
             <button
               className="relative flex items-center py-4 leading-none bg-black divide-x divide-gray-600 rounded-lg px-7 border-gray-300 disabled:bg-gray-700 disabled:cursor-not-allowed"
-              onClick={() => runCode(inputCodeRef.current)}
+              onClick={() => onRunCode(inputCodeRef.current)}
               disabled={isLoading}
             >
               <span className="text-gray-100 transition duration-200 group-hover:text-gray-100">

--- a/example-nextjs/components/Editor.tsx
+++ b/example-nextjs/components/Editor.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import Script from 'next/script'
 import MonacoEditor, { Monaco } from '@monaco-editor/react'
 import { addKeyBinding, CustomKeyBinding } from '../utils'
 
@@ -50,6 +51,10 @@ export default function Editor(props: Props) {
 
   return (
     <>
+      <Script
+        src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
+        strategy="beforeInteractive"
+      />
       <div>
         <div>
           <label className="block pb-4 text-sm font-medium text-gray-700 dark:text-gray-450">

--- a/example-nextjs/package.json
+++ b/example-nextjs/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "yarn run link-react && next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "link-react": "cd ./node_modules/react && yarn link && cd ../../../packages/run-wasm && yarn link \"react\""
   },
   "dependencies": {
     "@headlessui/react": "^1.4.1",

--- a/example-nextjs/package.json
+++ b/example-nextjs/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "yarn run link-react && next dev",
+    "prebuild": "yarn run link-react",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/example-nextjs/package.json
+++ b/example-nextjs/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@headlessui/react": "^1.4.1",
     "@heroicons/react": "^1.0.4",
-    "@monaco-editor/react": "^4.2.2",
     "fathom-client": "^3.0.0",
     "next": "11.1.2",
     "next-themes": "^0.0.15",

--- a/example-nextjs/yarn.lock
+++ b/example-nextjs/yarn.lock
@@ -131,21 +131,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@monaco-editor/loader@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.1.1.tgz#37db648c81a86946d0febd391de00df9c28a0a3d"
-  integrity sha512-mkT4r4xDjIyOG9o9M6rJDSzEIeonwF80sYErxEvAAL4LncFVdcbNli8Qv6NDqF6nyv6sunuKkDzo4iFjxPL+uQ==
-  dependencies:
-    state-local "^1.0.6"
-
-"@monaco-editor/react@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.2.2.tgz#636e5b8eb9519ef62f475f9a4a50f62ee0c493a8"
-  integrity sha512-yDDct+f/mZ946tJEXudvmMC8zXDygkELNujpJGjqJ0gS3WePZmS/IwBBsuJ8JyKQQC3Dy/+Ivg1sSpW+UvCv9g==
-  dependencies:
-    "@monaco-editor/loader" "^1.1.1"
-    prop-types "^15.7.2"
-
 "@napi-rs/triples@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.3.tgz#76d6d0c3f4d16013c61e45dfca5ff1e6c31ae53c"
@@ -3268,11 +3253,6 @@ stacktrace-parser@0.1.10:
   integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
   dependencies:
     type-fest "^0.7.1"
-
-state-local@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
-  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
 
 "statuses@>= 1.5.0 < 2":
   version "1.5.0"

--- a/example-nextjs/yarn.lock
+++ b/example-nextjs/yarn.lock
@@ -131,6 +131,21 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
+"@monaco-editor/loader@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.2.0.tgz#373fad69973384624e3d9b60eefd786461a76acd"
+  integrity sha512-cJVCG/T/KxXgzYnjKqyAgsKDbH9mGLjcXxN6AmwumBwa2rVFkwvGcUj1RJtD0ko4XqLqJxwqsN/Z/KURB5f1OQ==
+  dependencies:
+    state-local "^1.0.6"
+
+"@monaco-editor/react@^4.2.2":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.3.1.tgz#d65bcbf174c39b6d4e7fec43d0cddda82b70a12a"
+  integrity sha512-f+0BK1PP/W5I50hHHmwf11+Ea92E5H1VZXs+wvKplWUWOfyMa1VVwqkJrXjRvbcqHL+XdIGYWhWNdi4McEvnZg==
+  dependencies:
+    "@monaco-editor/loader" "^1.2.0"
+    prop-types "^15.7.2"
+
 "@napi-rs/triples@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.3.tgz#76d6d0c3f4d16013c61e45dfca5ff1e6c31ae53c"
@@ -2261,6 +2276,11 @@ modern-normalize@^1.1.0:
   resolved "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.1.0.tgz#da8e80140d9221426bd4f725c6e11283d34f90b7"
   integrity sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
 
+monaco-editor@^0.29.1:
+  version "0.29.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.29.1.tgz#6ee93d8a5320704d48fd7058204deed72429c020"
+  integrity sha512-rguaEG/zrPQSaKzQB7IfX/PpNa0qxF1FY8ZXRkN4WIl8qZdTQRSRJCtRto7IMcSgrU6H53RXI+fTcywOBC4aVw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3253,6 +3273,11 @@ stacktrace-parser@0.1.10:
   integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
   dependencies:
     type-fest "^0.7.1"
+
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
 
 "statuses@>= 1.5.0 < 2":
   version "1.5.0"

--- a/packages/run-wasm-python/README.md
+++ b/packages/run-wasm-python/README.md
@@ -47,8 +47,8 @@ yarn add @run-wasm/python
 ```jsx
 import React, { useEffect, useState, useRef } from 'react'
 import { createPythonClient } from '@run-wasm/python'
+import { Editor } from '@run-wasm/run-wasm
 import Script from 'next/script'
-import CodeRunnerUI from '../components/CodeRunnerUI'
 
 declare global {
   // <- [reference](https://stackoverflow.com/a/56458070/11542903)
@@ -73,10 +73,14 @@ eratosthenes(100)`
 
 function App() {
   const [pyodide, setPyodide] = useState(null)
+  const [output, setOutput] = React.useState('')
 
   async function runCode(code: string) {
     let pythonClient = createPythonClient(pyodide)
-    return await pythonClient.run({ code })
+    const output = await pythonClient.run({ code })
+    if (output) {
+      setOutput(output)
+    }
   }
 
   // Note that window.loadPyodide comes from the beforeInteractive pyodide.js Script
@@ -96,12 +100,14 @@ function App() {
         src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
         strategy="beforeInteractive"
       />
-      <CodeRunnerUI
+      <Editor
         initialCode={initialCode}
-        onRunCode={runCode}
+        output={output}
         languageLabel="Python"
-        isLoading={!pyodide}
+        hideOutputEditor={hideOutputEditor}
+        isLoading={isLoading}
         defaultLanguage="python"
+        onRunCode={runCode}
       />
     </>
   )

--- a/packages/run-wasm-python/tsconfig.json
+++ b/packages/run-wasm-python/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib"
+    "outDir": "./lib/esm"
   },
   "include": ["./src"]
 }

--- a/packages/run-wasm-ts/README.md
+++ b/packages/run-wasm-ts/README.md
@@ -45,8 +45,8 @@ yarn add @run-wasm/ts
 ```jsx
 import React, { useEffect, useState, useRef } from 'react'
 import { createTSClient } from '@run-wasm/ts'
+import { Editor } from '@run-wasm/run-wasm
 import Script, { initScriptLoader } from 'next/script'
-import CodeRunnerUI from '../components/CodeRunnerUI'
 
 declare global {
   interface Window {
@@ -65,6 +65,7 @@ console.log(a + b);`
 function App() {
   const [errors, setErrors] = useState<Array<string>>([])
   const [tsClient, setTsClient] = useState<any>(null)
+  const [output, setOutput] = React.useState('')
 
   function initialiseTsClient() {
     const tsClient = createTSClient(window.ts)
@@ -90,20 +91,24 @@ function App() {
   async function runCode(code: string) {
     const { errors, output } = await tsClient.run({ code })
     setErrors(errors)
-    return output
+    if (output) {
+      setOutput(output)
+    }
   }
 
   return (
     <>
       <Script strategy="beforeInteractive" src={tsScript} />
       <Script src="https://kit.fontawesome.com/137d63e13e.js" />
-      <CodeRunnerUI
-        initialCode={initialCode}
-        languageLabel="TypeScript"
-        defaultLanguage="typescript"
-        onRunCode={runCode}
-        isLoading={!tsClient}
-      >
+      <Editor
+          initialCode={initialCode}
+          output={output}
+          languageLabel="TypeScript"
+          hideOutputEditor={hideOutputEditor}
+          isLoading={isLoading}
+          defaultLanguage="typescript"
+          onRunCode={runCode}
+        >
         {errors.length > 0 && (
           <div>
             <label className="block pt-8 text-sm font-medium text-gray-700 dark:text-gray-450">
@@ -116,7 +121,7 @@ function App() {
             ))}
           </div>
         )}
-      </CodeRunnerUI>
+      </Editor>
     </>
   )
 }

--- a/packages/run-wasm/README.md
+++ b/packages/run-wasm/README.md
@@ -47,8 +47,8 @@ yarn add @run-wasm/python
 ```jsx
 import React, { useEffect, useState, useRef } from 'react'
 import { createPythonClient } from '@run-wasm/python'
+import { Editor } from '@run-wasm/run-wasm
 import Script from 'next/script'
-import CodeRunnerUI from '../components/CodeRunnerUI'
 
 declare global {
   // <- [reference](https://stackoverflow.com/a/56458070/11542903)
@@ -73,10 +73,14 @@ eratosthenes(100)`
 
 function App() {
   const [pyodide, setPyodide] = useState(null)
+  const [output, setOutput] = React.useState('')
 
   async function runCode(code: string) {
     let pythonClient = createPythonClient(pyodide)
-    return await pythonClient.run({ code })
+    const output = await pythonClient.run({ code })
+    if (output) {
+      setOutput(output)
+    }
   }
 
   // Note that window.loadPyodide comes from the beforeInteractive pyodide.js Script
@@ -96,12 +100,15 @@ function App() {
         src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
         strategy="beforeInteractive"
       />
-      <CodeRunnerUI
+      <Editor
         initialCode={initialCode}
-        onRunCode={runCode}
+        output={output}
         languageLabel="Python"
-        isLoading={!pyodide}
+        hideOutputEditor={hideOutputEditor}
+        isLoading={isLoading}
         defaultLanguage="python"
+        onRunCode={runCode}
+      />
       />
     </>
   )

--- a/packages/run-wasm/package.json
+++ b/packages/run-wasm/package.json
@@ -8,6 +8,10 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
+  "dependencies": {
+    "@monaco-editor/react": "^4.2.2",
+    "monaco-editor": "^0.29.1"
+  },
   "devDependencies": {
     "@types/react": "^17.0.21",
     "@types/react-dom": "^17.0.9",

--- a/packages/run-wasm/package.json
+++ b/packages/run-wasm/package.json
@@ -2,11 +2,11 @@
   "name": "@run-wasm/run-wasm",
   "version": "0.0.3",
   "main": "./lib/cjs/index.js",
-  "module": "./lib/esm/index.js",
-  "types": "./lib/esm/index.d.ts",
+  "module": "./lib/esm/src/index.js",
+  "types": "./lib/esm/src/index.d.ts",
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.2.2",
@@ -16,8 +16,6 @@
     "@types/react": "^17.0.21",
     "@types/react-dom": "^17.0.9",
     "jest": "^27.2.4",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.3"
   },

--- a/packages/run-wasm/src/Editor.tsx
+++ b/packages/run-wasm/src/Editor.tsx
@@ -54,13 +54,18 @@ export default function Editor(props: Props) {
     <>
       <div>
         <div>
-          <label className="block pb-4 text-sm font-medium text-gray-700 dark:text-gray-450">
+          <label
+            style={{
+              color: 'rgba(107, 114, 128)',
+              fontSize: '.875rem',
+              fontWeight: 600,
+            }}
+          >
             {languageLabel}
           </label>
 
-          <div className="mt-1 ">
-            <div className="relative group">
-              <div className="absolute -inset-0.5 dark:bg-gradient-to-r from-indigo-300 to-purple-400 rounded-lg blur opacity-25 group-hover:opacity-100 transition duration-1000 group-hover:duration-200 animate-tilt" />
+          <div style={{ marginTop: '1rem' }}>
+            <div>
               <MonacoEditor
                 height="20rem"
                 defaultLanguage={defaultLanguage}
@@ -68,7 +73,6 @@ export default function Editor(props: Props) {
                 onChange={(value) => {
                   inputCodeRef.current = value || ''
                 }}
-                className="block w-1/2  text-white bg-gray-900 border-gray-300 rounded-lg   shadow-sm p-0.5 border   dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
                 theme="vs-dark"
                 options={{ fontSize: 12, minimap: { enabled: false } }}
                 onMount={handleEditorDidMount}
@@ -78,36 +82,45 @@ export default function Editor(props: Props) {
         </div>
       </div>
 
-      <div className="pt-8 ">
-        <div className="grid items-start justify-left">
-          <div className="relative group">
-            <button
-              className="relative flex items-center py-4 leading-none bg-black divide-x divide-gray-600 rounded-lg px-7 border-gray-300 disabled:bg-gray-700 disabled:cursor-not-allowed"
-              onClick={() => onRunCode(inputCodeRef.current)}
-              disabled={isLoading}
-            >
-              <span className="text-gray-100 transition duration-200 group-hover:text-gray-100">
-                {!isLoading ? 'Run Code →' : `Loading ${languageLabel}...`}
-              </span>
-            </button>
-          </div>
-        </div>
+      <div style={{ padding: '2rem 0' }}>
+        <button
+          onClick={() => onRunCode(inputCodeRef.current)}
+          disabled={isLoading}
+          style={{
+            borderRadius: '.5rem',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '1rem 1.75rem',
+            lineHeight: 1,
+            backgroundColor: 'black',
+          }}
+        >
+          <span style={{ color: 'rgba(243,244,246' }}>
+            {!isLoading ? 'Run Code →' : `Loading ${languageLabel}...`}
+          </span>
+        </button>
       </div>
 
       {children}
 
       {!hideOutputEditor && (
         <div>
-          <label className="block pt-8 text-sm font-medium text-gray-700 dark:text-gray-450">
+          <label
+            style={{
+              color: 'rgba(107, 114, 128)',
+              fontSize: '.875rem',
+              fontWeight: 600,
+            }}
+          >
             Output
           </label>
 
-          <div className="mt-1 dark:text-gray-450">
+          <div style={{ marginTop: '1rem' }}>
             <MonacoEditor
               value={output?.toString()}
               height="20rem"
               defaultLanguage="python"
-              className="block w-1/2 text-white bg-gray-900 border-gray-300 rounded-lg shadow-sm p-0.5 border dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
               theme="vs-dark"
               options={{
                 readOnly: true,

--- a/packages/run-wasm/src/Editor.tsx
+++ b/packages/run-wasm/src/Editor.tsx
@@ -65,7 +65,7 @@ export default function Editor(props: Props) {
           </label>
 
           <div style={{ marginTop: '1rem' }}>
-            <div>
+            <div style={{ borderRadius: '0.5rem', overflow: 'hidden' }}>
               <MonacoEditor
                 height="20rem"
                 defaultLanguage={defaultLanguage}
@@ -74,7 +74,11 @@ export default function Editor(props: Props) {
                   inputCodeRef.current = value || ''
                 }}
                 theme="vs-dark"
-                options={{ fontSize: 12, minimap: { enabled: false } }}
+                options={{
+                  fontSize: 12,
+                  minimap: { enabled: false },
+                  padding: { top: 16 },
+                }}
                 onMount={handleEditorDidMount}
               />
             </div>
@@ -116,7 +120,13 @@ export default function Editor(props: Props) {
             Output
           </label>
 
-          <div style={{ marginTop: '1rem' }}>
+          <div
+            style={{
+              marginTop: '1rem',
+              borderRadius: '0.5rem',
+              overflow: 'hidden',
+            }}
+          >
             <MonacoEditor
               value={output?.toString()}
               height="20rem"
@@ -126,6 +136,7 @@ export default function Editor(props: Props) {
                 readOnly: true,
                 fontSize: 12,
                 minimap: { enabled: false },
+                padding: { top: 16 },
               }}
             />
           </div>

--- a/packages/run-wasm/src/Editor.tsx
+++ b/packages/run-wasm/src/Editor.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable */
+
 import * as React from 'react'
-import Script from 'next/script'
 import MonacoEditor, { Monaco } from '@monaco-editor/react'
 import { addKeyBinding, CustomKeyBinding } from '../utils'
 
@@ -29,7 +30,7 @@ export default function Editor(props: Props) {
   const inputCodeRef = React.useRef(initialCode)
   const editorRef = React.useRef(null)
 
-  const [monaco, setMonaco] = React.useState<Monaco>(null)
+  const [monaco, setMonaco] = React.useState<Monaco | null>(null)
 
   function handleEditorDidMount(editor: any, monaco: Monaco) {
     editorRef.current = editor
@@ -51,10 +52,6 @@ export default function Editor(props: Props) {
 
   return (
     <>
-      <Script
-        src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"
-        strategy="beforeInteractive"
-      />
       <div>
         <div>
           <label className="block pb-4 text-sm font-medium text-gray-700 dark:text-gray-450">
@@ -69,7 +66,7 @@ export default function Editor(props: Props) {
                 defaultLanguage={defaultLanguage}
                 defaultValue={inputCodeRef.current}
                 onChange={(value) => {
-                  inputCodeRef.current = value
+                  inputCodeRef.current = value || ''
                 }}
                 className="block w-1/2  text-white bg-gray-900 border-gray-300 rounded-lg   shadow-sm p-0.5 border   dark:border-purple-300 focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
                 theme="vs-dark"

--- a/packages/run-wasm/src/index.tsx
+++ b/packages/run-wasm/src/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react'
 import { RunWasmClient } from './RunWasmClient'
+import Editor from './Editor'
 
 declare global {
   // <- [reference](https://stackoverflow.com/a/56458070/11542903)
@@ -31,4 +32,4 @@ const createRunWasmClient = (language: string): RunWasmClient => {
   return new RunWasmClient(language)
 }
 
-export { RunWasm, createRunWasmClient }
+export { RunWasm, createRunWasmClient, Editor }

--- a/packages/run-wasm/tsconfig.json
+++ b/packages/run-wasm/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib"
+    "outDir": "./lib/esm"
   },
   "include": ["./src"]
 }

--- a/packages/run-wasm/utils/index.ts
+++ b/packages/run-wasm/utils/index.ts
@@ -1,4 +1,6 @@
-//fix the type of "keybinding" and "editorRef"
+/* eslint-disable */
+
+// TODO: fix the type of "keybinding" and "editorRef"
 export interface CustomKeyBinding {
   label: string
   keybinding: any

--- a/packages/run-wasm/yarn.lock
+++ b/packages/run-wasm/yarn.lock
@@ -487,6 +487,21 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@monaco-editor/loader@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.2.0.tgz#373fad69973384624e3d9b60eefd786461a76acd"
+  integrity sha512-cJVCG/T/KxXgzYnjKqyAgsKDbH9mGLjcXxN6AmwumBwa2rVFkwvGcUj1RJtD0ko4XqLqJxwqsN/Z/KURB5f1OQ==
+  dependencies:
+    state-local "^1.0.6"
+
+"@monaco-editor/react@^4.2.2":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.3.1.tgz#d65bcbf174c39b6d4e7fec43d0cddda82b70a12a"
+  integrity sha512-f+0BK1PP/W5I50hHHmwf11+Ea92E5H1VZXs+wvKplWUWOfyMa1VVwqkJrXjRvbcqHL+XdIGYWhWNdi4McEvnZg==
+  dependencies:
+    "@monaco-editor/loader" "^1.2.0"
+    prop-types "^15.7.2"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -1883,7 +1898,7 @@ lodash@4.x, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.1.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1957,6 +1972,11 @@ minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+monaco-editor@^0.29.1:
+  version "0.29.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.29.1.tgz#6ee93d8a5320704d48fd7058204deed72429c020"
+  integrity sha512-rguaEG/zrPQSaKzQB7IfX/PpNa0qxF1FY8ZXRkN4WIl8qZdTQRSRJCtRto7IMcSgrU6H53RXI+fTcywOBC4aVw==
 
 ms@2.1.2:
   version "2.1.2"
@@ -2122,6 +2142,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -2140,6 +2169,11 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^17.0.1:
   version "17.0.2"
@@ -2284,6 +2318,11 @@ stack-utils@^2.0.3:
   integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
 
 string-length@^4.0.1:
   version "4.0.2"

--- a/packages/run-wasm/yarn.lock
+++ b/packages/run-wasm/yarn.lock
@@ -1898,7 +1898,7 @@ lodash@4.x, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2161,15 +2161,6 @@ punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
-
 react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -2179,14 +2170,6 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -2236,14 +2219,6 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 semver@7.x, semver@^7.3.2:
   version "7.3.5"


### PR DESCRIPTION
closes #100 

This PR pulls the UI in the screenshot below into a separate React component inside the core `run-wasm` package. 

A user could import this component from the package to use this default interface. `import { Editor } from '@run-wasm/runwasm'`

![image](https://user-images.githubusercontent.com/49968061/139569566-799558ed-bf92-491b-976c-2338968ebb11.png)
